### PR TITLE
Add encoding to XML parser

### DIFF
--- a/pytouchline/__init__.py
+++ b/pytouchline/__init__.py
@@ -1,5 +1,6 @@
 import httplib2
-from xml.etree.ElementTree import XML as xml
+import cchardet as chardet
+import xml.etree.ElementTree as ET
 
 __author__ = 'abondoe'
 
@@ -125,7 +126,8 @@ class PyTouchline(object):
 		if resp.reason != "OK":
 			exit("Network error")
 		else:
-			return xml(content)
+			enc = chardet.detect(content)['encoding']
+			return ET.XML(content, parser=ET.XMLParser(encoding=enc))
 
 	def _parse_number_of_devices(self, response):
 		item_list = response.find('item_list')

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
 	'License :: OSI Approved :: MIT License',
 	'Programming Language :: Python :: 3',
   ],
-  install_requires=['httplib2']
+  install_requires=['httplib2', 'cchardet']
 )


### PR DESCRIPTION
The XML parser assumes that the response from the Touchline API is in UTF-8, but it looks like it is actually Latin-1. This results in an error in the parser which means that rooms with special characters like the danish æ, ø, å is left out of the result returned from pytouchline.

I have added encoding detection using cchardet to ensure that the room names are parsed correctly. Tested on my setup with Roth Touchline firmware 2.8.

Thanks for your work with this integration :-)

/Rasmus
