### PR TITLE
Add get_hostname method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple helper library for controlling a Roth Touchline heat pump controller
 
 ```py
 
-from pytouchline import PyTouchline
+from pytouchlineplus import PyTouchline
 
 py_touchline = PyTouchline()
 

--- a/pytouchline/__init__.py
+++ b/pytouchline/__init__.py
@@ -2,7 +2,7 @@ import httplib2
 import cchardet as chardet
 import xml.etree.ElementTree as ET
 
-__author__ = 'abondoe'
+__author__ = 'pilehave'
 
 
 class PyTouchline(object):

--- a/pytouchline/__init__.py
+++ b/pytouchline/__init__.py
@@ -48,6 +48,13 @@ class PyTouchline(object):
 		response = self._request_and_receive_xml(request)
 		return self._parse_number_of_devices(response)
 
+	def get_hostname(self):
+		hostname_items = []
+		hostname_items.append("<i><n>hw.HostName</n></i>")
+		request = self._get_touchline_request(hostname_items)
+		response = self._request_and_receive_xml(request)
+		return self._parse_number_of_devices(response)
+
 	def get_status(self):
 		status_items = []
 		status_items.append("<i><n>R0.SystemStatus</n></i>")

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from distutils.core import setup
 setup(
-  name = 'pytouchline',
-  packages = ['pytouchline'],
-  version = '0.7',
+  name = 'pytouchlineplus',
+  packages = ['pytouchlineplus'],
+  version = '0.8',
   description = 'A Roth Touchline interface library',
-  author = 'Aksel Bondoe',
-  author_email = 'aksel.bondoe@gmail.com',
+  author = 'Mikkel Pilehave Jensen',
+  author_email = 'pilehave@gmail.com',
   license='MIT',
-  url = 'https://github.com/abondoe/pytouchline',
-  download_url = 'https://github.com/abondoe/pytouchline/archive/0.7.tar.gz',
+  url = 'https://github.com/pilehave/pytouchlineplus',
+  download_url = 'https://github.com/pilehave/pytouchlineplus/archive/0.8.tar.gz',
   keywords = ['Roth', 'Touchline', 'Home Assistant', 'hassio', "Heat pump"],
   classifiers = [
 	'Development Status :: 3 - Alpha',


### PR DESCRIPTION
In Home Assistant the hostname is useful, as it seems to be unique to the unit. So, I added the method to return the hostname from the XML.